### PR TITLE
Add hwdata package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN make clean && make build
 # Create the sriov-network-device-plugin image
 FROM ${UBI_IMAGE}
 WORKDIR /
+RUN microdnf update -y && \
+    microdnf install hwdata
 COPY --from=builder /go/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /go/sriov-network-device-plugin/images/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Otherwise we get the error:

`E0226 14:01:52.445948       1 main.go:62] error discovering host devicesdiscoverDevices(): error getting PCI info: gzip: invalid header`

Signed-off-by: Manuel Buil <mbuil@suse.com>