### PR TITLE
Temporarily disable drone tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ ORG ?= rancher
 # last commit on 2021-10-06
 TAG ?= 441e06f11bfafcf5f818975298943537a103b5a8$(BUILD_META)
 
-ifneq ($(DRONE_TAG),)
-TAG := $(DRONE_TAG)
-endif
+# Temporarily disable this as Github tags can't be a SHA (too long)
+#ifneq ($(DRONE_TAG),)
+#TAG := $(DRONE_TAG)
+#endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))


### PR DESCRIPTION
Github does not allow SHA as tags

Signed-off-by: Manuel Buil <mbuil@suse.com>