### PR TITLE
BCI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ RUN make clean && make build
 # Create the sriov-network-device-plugin image
 FROM ${BCI_IMAGE}
 WORKDIR /
-RUN zypper install -y hwdata
+RUN zypper refresh && \
+    zypper update -y && \
+    zypper install -y hwdata gawk which && \
+    zypper clean -a
 COPY --from=builder /go/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /go/sriov-network-device-plugin/images/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAG="v3.5.1"
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.18.5b7
 
 # Build the project
@@ -16,10 +16,9 @@ RUN git checkout tags/${TAG} -b ${TAG}
 RUN make clean && make build
 
 # Create the sriov-network-device-plugin image
-FROM ${UBI_IMAGE}
+FROM ${BCI_IMAGE}
 WORKDIR /
-RUN microdnf update -y && \
-    microdnf install hwdata
+RUN zypper install -y hwdata
 COPY --from=builder /go/sriov-network-device-plugin/build/sriovdp /usr/bin/
 COPY --from=builder /go/sriov-network-device-plugin/images/entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR replaces UBI7 with BCI in the final base image. Related to https://github.com/rancher/rke2/issues/3260.