### PR TITLE
Add dependabot label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"
 
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "kind/dependabot"
     reviewers:
       - "rancher/k3s"
 


### PR DESCRIPTION
This adds label "kind/dependabot" to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4130.
This contributes to https://github.com/rancher/rke2/issues/4165
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
{
  "input": {
    "job": {
      "package-manager": "docker",
      "allowed-updates": [
        {
          "update-type": "all"
        }
      ],
      "source": {
        "provider": "github",
        "repo": "matttrach/image-build-sriov-network-device-plugin",
        "directory": "/",
        "commit": "130172dcb24f857acee396dbf0687849e80ae7b3"
      },
      "credentials-metadata": [
        {
          "host": "github.com",
          "type": "git_source"
        }
      ]
    },
    "credentials": [
      {
        "host": "github.com",
        "password": "$LOCAL_GITHUB_ACCESS_TOKEN",
        "type": "git_source",
        "username": "x-access-token"
      }
    ]
  },
  "output": [
    {
      "type": "update_dependency_list",
      "expect": {
        "data": {
          "dependencies": [],
          "dependency_files": [
            "/Dockerfile"
          ]
        }
      }
    },
    {
      "type": "mark_as_processed",
      "expect": {
        "data": {
          "base-commit-sha": "130172dcb24f857acee396dbf0687849e80ae7b3"
        }
      }
    }
  ]
}
```

</details>