### PR TITLE
Bump build base version to v1.21.10b1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG="v3.6.2"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
-ARG GO_IMAGE=rancher/hardened-build-base:v1.21.8b1
+ARG GO_IMAGE=rancher/hardened-build-base:v1.21.10b1
 
 # Build the project
 FROM ${GO_IMAGE} as builder


### PR DESCRIPTION



<Actions>
    <action id="d7f92eb0a3abcc03eb3474bea328769484d749891e0e93b7e9b5db417816ef2d">
        <h3>Update build base version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump to latest build base version in Dockerfile</summary>
            <p>changed lines [3] of file &#34;/tmp/updatecli/github/rancher/image-build-sriov-network-device-plugin/Dockerfile&#34;</p>
            <details>
                <summary>v1.21.10b1</summary>
                <pre>&#xA;Release published on the 2024-05-08 17:08:54 +0000 UTC at the url https://github.com/rancher/image-build-base/releases/tag/v1.21.10b1&#xA;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

