### PR TITLE
Bump to upstream version v3.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG="v3.6.2"
+ARG TAG=v3.7.0
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
 ARG GO_IMAGE=rancher/hardened-build-base:v1.22.4b2
 
@@ -8,7 +8,7 @@ RUN set -x && \
     apk --no-cache add patch \
     git \
     make
-ARG TAG
+ARG TAG=v3.7.0
 RUN git clone https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin
 WORKDIR sriov-network-device-plugin
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ORG ?= rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v3.6.2$(BUILD_META)
+TAG := v3.7.0$(BUILD_META)
 endif
 
 


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v3.7.0</summary>
            <p>1 file(s) updated with &#34;TAG := v3.7.0$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v3.7.0</summary>
            <p>changed lines [1 11] of file &#34;/tmp/updatecli/github/rancher/image-build-sriov-network-device-plugin/Dockerfile&#34;</p>
            <details>
                <summary>v3.7.0</summary>
                <pre>&#xA;Release published on the 2024-06-03 10:50:06 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/releases/tag/v3.7.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* Bump the gomod-dependencies group with 2 updates by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/518&#xD;&#xA;* Bump the gomod-dependencies group with 1 update by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/522&#xD;&#xA;* Add fallback to get PF Name for AuxNetDevice by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/526&#xD;&#xA;* Update go version and github actions to 1.21 by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/527&#xD;&#xA;* Allow to filter net devices by Infiniband Partition Key by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/517&#xD;&#xA;* Downgrade ddp-builder container version by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/529&#xD;&#xA;* Bump the gomod-dependencies group with 4 updates by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/537&#xD;&#xA;* Expose RDMA device name in the devicespec if available by @almaslennikov in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/530&#xD;&#xA;* run k8s functional tests by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/541&#xD;&#xA;* Update deployment yamls by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/543&#xD;&#xA;* Bump the gomod-dependencies group with 5 updates by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/550&#xD;&#xA;* remove grpc deprication functions by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/551&#xD;&#xA;* 🌱 Making workflows not run on forks. by @adilGhaffarDev in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/540&#xD;&#xA;* Revert &#34;🌱 Making workflows not run on forks.&#34; by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/557&#xD;&#xA;* remove vendoring, use Go modules by default by @jaypipes in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/548&#xD;&#xA;* Support for acquiring DDP profile using devlink by @ipatrykx in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/387&#xD;&#xA;* allow to run unit-tests inside a container by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/561&#xD;&#xA;* Bump golang.org/x/net from 0.21.0 to 0.23.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/553&#xD;&#xA;* Bump github.com/opencontainers/runc from 1.1.5 to 1.1.12 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/532&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @adilGhaffarDev made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/540&#xD;&#xA;* @jaypipes made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pull/548&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/compare/v3.6.2...v3.7.0</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

