### PR TITLE
updatecli: use `semver` versionfilter

### DIFF
--- a/updatecli/updatecli.d/update-upstream.yaml
+++ b/updatecli/updatecli.d/update-upstream.yaml
@@ -13,9 +13,8 @@ sources:
        release: true
        draft: false
        prerelease: false
-       latest: true
      versionfilter:
-       kind: latest
+       kind: semver
 
 targets:
   dockerfile:


### PR DESCRIPTION
Version bump PRs should use the semver instead of the latest tag

Issue: https://github.com/rancher/rke2/issues/6402