### PR TITLE
Statically compile the `sriovdp` binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN git fetch --all --tags --prune
 RUN git checkout tags/${TAG} -b ${TAG}
 COPY logs.patch .
 RUN patch -p1 < logs.patch
-RUN make clean && make build
+RUN make clean && \
+    make STATIC=1 build
 
 # Create the sriov-network-device-plugin image
 FROM ${BCI_IMAGE}


### PR DESCRIPTION
The `sriovdp` binary is dynamically linked by default when built against the upstream `v3.8.0` release, where prior versions of the upstream binary were statically linked. 

The downstream rancher binary is built against Alpine Linux and then copied into a target BCI container image that  is not able to provide the needed [musl libc](https://musl.libc.org/) library.